### PR TITLE
fix: Properly define requirements for packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.7',
-    install_requires=[ ],
+    install_requires=[ regex ],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
According to the docs `regex` is a requirement of the package, so we need to specify it in order to allow third party devs to use the package with its transient dependencies. 

In the best case we would also add some version constraints, if any, but I don't know about this.